### PR TITLE
Client: Change the name of response object to `HTTPResponse`.

### DIFF
--- a/httpclient.py
+++ b/httpclient.py
@@ -27,7 +27,7 @@ import urllib
 def help():
     print "httpclient.py [GET/POST] [URL]\n"
 
-class HTTPRequest(object):
+class HTTPResponse(object):
     def __init__(self, code=200, body=""):
         self.code = code
         self.body = body
@@ -63,12 +63,12 @@ class HTTPClient(object):
     def GET(self, url, args=None):
         code = 500
         body = ""
-        return HTTPRequest(code, body)
+        return HTTPResponse(code, body)
 
     def POST(self, url, args=None):
         code = 500
         body = ""
-        return HTTPRequest(code, body)
+        return HTTPResponse(code, body)
 
     def command(self, url, command="GET", args=None):
         if (command == "POST"):

--- a/requirements.org
+++ b/requirements.org
@@ -24,7 +24,7 @@
    - As a user I want to POST from URLs that use virtualhosting
    - As a user when I GET or POST I want the result printed to stdout
    - As a developer when I GET or POST I want the result returned as
-     a HTTPRequest object
+     a HTTPResponse object
 
 ** Requirements
    - [ ] Implement basic HTTP GET


### PR DESCRIPTION
For the httpclient, to use `HTTPRequest` is a bad idea to store the HTTP Response data. 

1. Confuse the people. The name `Request` is a well know name, and it is usually refereeing to the object which store the pre-process data (http header, URL, user-agent…). 
django:(https://docs.djangoproject.com/en/1.9/ref/request-response/).
urilib2: (https://docs.python.org/2/library/urllib2.html#urllib2.OpenerDirector.add_handler)

2. If we use `HTTPRequest` to store the HTTP Response data, it very difficult to naming another object to store pre-process data. 