### PR TITLE
Correct typos in requirements

### DIFF
--- a/requirements.org
+++ b/requirements.org
@@ -13,7 +13,7 @@
      own source code.
    - You may work (pair program) with 1 other person, but both of you
      need to submit your work separately.
-   - Collaboration but be documents in the README.md file
+   - Collaboration must be documented in the README.md file
    - Any external source code must be referenced and documented in
      the README.md file
 
@@ -64,9 +64,9 @@
      - Line 3: Your collaborator's CCID
 
    - To mark your assignment I should be able to type:
-     git clone http://github.com/youruserid/thisassignment.git yourccid
-     cd yourccid
-     python freetests.py
+    : git clone http://github.com/youruserid/thisassignment.git yourccid
+    : cd yourccid
+    : python freetests.py
 
    - Marks will be deducted if I cannot successfully do this.
      

--- a/requirements.org
+++ b/requirements.org
@@ -47,8 +47,7 @@
    - [ ] You should use the socket library that comes with python
 
 ** Recommendations
-   - Use the server.py skeleton. Handling sockets yourself is not
-     that fun
+   - Use the httpclient.py skeleton.
    - Keep it short, keep it modular
    - READ the spec, read the format of a request
    - It's a good idea to send the Host header in a GET or POST


### PR DESCRIPTION
Self-explanatory. Also note in the recommendations, it states:

> It’s a good idea to send the Host header in a GET or POST

*~Pedantically speaking~*, [it's required by the spec][http]. So "good idea" is an understatement. I guess realizing that virtualhosts exists is part of this assignment, so maybe that wording makes sense.

[http]: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23